### PR TITLE
Use google photos

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/VideoActivity.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/VideoActivity.java
@@ -383,7 +383,7 @@ public class VideoActivity extends AppCompatActivity{
         String[] complexCommand = {"-y", "-i", videoPath, "-an", "-r", "20", "-ss", "" + startMs / 1000, "-t", "" + (endMs - startMs) / 1000, jpegFile.getAbsolutePath()};
         /*   Remove -r 1 if you want to extract all video frames as images from the specified time duration.*/
         execFFmpegBinary(complexCommand);
-        generateFrames.setBackgroundColor(Color.parseColor("#00CC00"));
+
 //        Intent goHome = new Intent(getApplicationContext(), ImageActivity.class);
 //        startActivity(goHome);
     }
@@ -405,6 +405,9 @@ public class VideoActivity extends AppCompatActivity{
                     Log.d(TAG, "SUCCESS with output : " + s);
                     Toast.makeText(VideoActivity.this, "Frames Generation Completed", Toast.LENGTH_SHORT).show();
                     Toast.makeText(VideoActivity.this, "Head Over to the Image Upload Section", Toast.LENGTH_SHORT).show();
+
+                    RealPathUtil.deleteIfTempFile(VideoActivity.this, videoPath);
+                    generateFrames.setBackgroundColor(Color.parseColor("#00CC00"));
                 }
 
                 @Override

--- a/app/src/main/java/com/onrpiv/uploadmedia/Utilities/RealPathUtil.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Utilities/RealPathUtil.java
@@ -156,9 +156,11 @@ public class RealPathUtil {
     }
 
     /**
-     * Get the path of a Stream Uri (Google Photos)
+     * Get path of a stream Uri (e.g. Google Photos) by creating a temporary file in app's data directory.
      * see https://stackoverflow.com/questions/35909008/pick-image-from-gallery-or-google-photos-failing/50253933#50253933
-     *
+     * @param context context of the activity; Needed for app's data directory
+     * @param uri stream uri
+     * @return path of newly created temp file created from uri data stream
      */
     public static String getPathFromInputStreamUri(Context context, Uri uri) {
         InputStream inputStream = null;
@@ -252,6 +254,11 @@ public class RealPathUtil {
         return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
     }
 
+    /**
+     * @param context VideoActivity context. Needed for data directory.
+     * @param path Path of the video.
+     * @return True if temp file and deleted successfully, otherwise False.
+     */
     public static boolean deleteIfTempFile(Context context, String path) {
         File tempFile = new File(context.getApplicationInfo().dataDir, "tempFile");
         boolean result = false;
@@ -263,6 +270,13 @@ public class RealPathUtil {
         return result;
     }
 
+    /**
+     * Create a temporary file from a data stream in the app's data directory.
+     * @param inputStream input data stream
+     * @param dataDir app's data directory
+     * @return File object pointing to the newly created temp file
+     * @throws IOException if data stream is unable to close.
+     */
     private static File createTemporalFileFrom(InputStream inputStream, String dataDir) throws IOException {
         File targetFile = null;
 

--- a/app/src/main/java/com/onrpiv/uploadmedia/Utilities/RealPathUtil.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Utilities/RealPathUtil.java
@@ -15,6 +15,16 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.util.Log;
+
+import org.opencv.android.Utils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class RealPathUtil {
 
@@ -133,7 +143,7 @@ public class RealPathUtil {
 
             // Return the remote address
             if (isGooglePhotosUri(uri))
-                return uri.getLastPathSegment();
+                return getPathFromInputStreamUri(context, uri);
 
             return getDataColumn(context, uri, null, null);
         }
@@ -143,6 +153,37 @@ public class RealPathUtil {
         }
 
         return null;
+    }
+
+    /**
+     * Get the path of a Stream Uri (Google Photos)
+     * see https://stackoverflow.com/questions/35909008/pick-image-from-gallery-or-google-photos-failing/50253933#50253933
+     *
+     */
+    public static String getPathFromInputStreamUri(Context context, Uri uri) {
+        InputStream inputStream = null;
+        String filePath = null;
+
+        String dataDir = context.getApplicationInfo().dataDir;
+
+        try {
+            inputStream = context.getContentResolver().openInputStream(uri);
+            File file = createTemporalFileFrom(inputStream, dataDir);
+            filePath = file.getPath();
+        } catch (FileNotFoundException e) {
+            Log.getStackTraceString(e);
+        } catch (IOException e) {
+            Log.getStackTraceString(e);
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return filePath;
     }
 
     /**
@@ -208,7 +249,30 @@ public class RealPathUtil {
      * @return Whether the Uri authority is Google Photos.
      */
     public static boolean isGooglePhotosUri(Uri uri) {
-        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+        return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
     }
 
+    private static File createTemporalFileFrom(InputStream inputStream, String dataDir) throws IOException {
+        File targetFile = null;
+
+        if (inputStream != null) {
+            int read;
+            byte[] buffer = new byte[8 * 1024];
+
+            targetFile = new File(dataDir, "tempFile");
+            OutputStream outputStream = new FileOutputStream(targetFile);
+
+            while ((read = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, read);
+            }
+            outputStream.flush();
+
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return targetFile;
+    }
 }

--- a/app/src/main/java/com/onrpiv/uploadmedia/Utilities/RealPathUtil.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Utilities/RealPathUtil.java
@@ -252,6 +252,17 @@ public class RealPathUtil {
         return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
     }
 
+    public static boolean deleteIfTempFile(Context context, String path) {
+        File tempFile = new File(context.getApplicationInfo().dataDir, "tempFile");
+        boolean result = false;
+
+        if (tempFile.getAbsolutePath().equals(path)) {
+            result = tempFile.delete();
+        }
+
+        return result;
+    }
+
     private static File createTemporalFileFrom(InputStream inputStream, String dataDir) throws IOException {
         File targetFile = null;
 


### PR DESCRIPTION
Fixes #25 by creating a temporary file to extract frames from, and subsequently deleting the file if frame generation is successful.