### PR TITLE
Back arrow add on

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/Learn/FluidGlossary.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Learn/FluidGlossary.java
@@ -16,7 +16,7 @@ import com.onrpiv.uploadmedia.Experiment.HomeActivity;
 import com.onrpiv.uploadmedia.Experiment.VideoActivity;
 import com.onrpiv.uploadmedia.R;
 
-public class FluidGlossary extends Activity {
+public class FluidGlossary extends LearnFluids {
     // Array of strings...
     String[] mobileArray = {"Boundary Layer","Laminar and Turbulent Flow","Reynolds Number","Vorticity/Circulation",
             "Fluid","Wake","Shear","Velocity profile","Streamline","Steady/Unsteady",

--- a/app/src/main/java/com/onrpiv/uploadmedia/Learn/LearnFluids.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Learn/LearnFluids.java
@@ -25,6 +25,8 @@ public class LearnFluids extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.learn_fluids);
 
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         fluidGlossaryButton = (Button)findViewById(R.id.fluidGlossaryButton);
         fluidGlossaryButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -71,4 +73,15 @@ public class LearnFluids extends AppCompatActivity {
             return true;
         }
     };
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
 }

--- a/app/src/main/java/com/onrpiv/uploadmedia/Learn/LearnPIV.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Learn/LearnPIV.java
@@ -27,6 +27,8 @@ public class LearnPIV extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.learn_piv);
 
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         pivBasicsButton = (Button)findViewById(R.id.pivBasicsButton);
         pivBasicsButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -91,4 +93,15 @@ public class LearnPIV extends AppCompatActivity {
             return true;
         }
     };
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
 }

--- a/app/src/main/java/com/onrpiv/uploadmedia/Learn/VideoTutorial.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Learn/VideoTutorial.java
@@ -7,7 +7,7 @@ import android.widget.ListView;
 
 import com.onrpiv.uploadmedia.R;
 
-public class VideoTutorial extends AppCompatActivity {
+public class VideoTutorial extends LearnPIV {
 
     String [] tutorialArray = {"Choosing an Experiment","Setting up an Experiment","Getting the lighting Right","How Big can my Experiment be?",
     "All About Lasers!","Selecting the right Seed Particles","How PIV calculates Flow Velocity","How mI-PIV works"};


### PR DESCRIPTION
Added back arrow functionality to LearnFluids and LearnPIV. The nice thing is, we only have to add the function to these two classes because they are the parents of all the other subclasses; the back arrow will be visible until the user navigates all the way back to the parent. I didn't add this to the Experiment side of the app yet because there's already a function inside ImageActivity that does the same thing which might cause bugs. 