### PR TITLE
Added the previous function and line of code back into ImageActivity.java.

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ImageActivity.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ImageActivity.java
@@ -46,6 +46,7 @@ public class ImageActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.image_layout);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         // init buttons
         pickImageMultiple = (Button) findViewById(R.id.pickImageMultiple);
@@ -73,6 +74,16 @@ public class ImageActivity extends AppCompatActivity {
         new LightBulb(context, compute).setLightBulbOnClick("Compute PIV",
                 "Compute PIV computes the velocity field between the first and second image from \"Select An Image Pair\" according to the parameters in \"Input PIV Parameters\". For more information see: ",
                 new PIVBasicsLayout(), "Learn More", getWindow());
+    }
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 
     public void onClick_MultipleImages(View view) {


### PR DESCRIPTION
What we could do, and what we've done before, is just add the one line of code:

getSupportActionBar().setDisplayHomeAsUpEnabled(true);

and the following function: 

public boolean onOptionsItemSelected(MenuItem item) {...}

inside of the parent class and the back arrow would take care of itself throughout the rest of the app. However, we cannot make ImageActivity.java a child of MainActivity.java, therefore we must have the code above in both of these classes. In future refactoring we can consider placing this code in a parent class so as to not reuse code. For now the app is functioning. 