### PR TITLE
Frames resizing on extraction

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/Utilities/FrameExtractor.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Utilities/FrameExtractor.java
@@ -70,9 +70,9 @@ public class FrameExtractor {
             The value is a time duration See more https://ffmpeg.org/ffmpeg-utils.html#Time-duration.
         -t  total duration or when to stop processing.
             The value is a time duration. See more https://ffmpeg.org/ffmpeg-utils.html#Time-duration.
+        scale= Set the resolution of the frames. See more https://trac.ffmpeg.org/wiki/Scaling
          */
-        String[] complexCommand = {"-y", "-i", videoPath, "-an", "-r", fps, "-ss", "" + videoStart, "-t", "" + (videoEnd - videoStart), jpegFile.getAbsolutePath()};
-        /*   Remove -r 1 if you want to extract all video frames as images from the specified time duration.*/
+        String[] complexCommand = {"-y", "-i", videoPath, "-an", "-r", fps, "-ss", "" + videoStart, "-t", "" + (videoEnd - videoStart), "-vf", "scale=1080:-1", jpegFile.getAbsolutePath()};
         execFFmpegBinary(complexCommand, context, thisCallback);
     }
 


### PR DESCRIPTION
- Fixes PIV memory issues by resizing extracted frames to 1080 width and maintains aspect ratio.
- Should be considered a temporary fix while PIV memory optimization is being worked on.