### PR TITLE
Post-Processing and Multipass index fix

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivFunctions.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivFunctions.java
@@ -755,7 +755,7 @@ public class PivFunctions {
 
                 // DONT ERASE COMMENTED LINE BELOW IN CASE WE NEED TO USE A SIMILAR LOGIC LATER
                 //if (pivCorrelation.get("magnitude")[k][l] * dt < nMaxUpper && pivCorrelation.get("sig2Noise")[k][l] > qMin && r_r < _e && r_c < _e) {
-                if (singlePassResult.getSig2Noise()[k][l] > qMin && r_r < _e && r_c < _e && singlePassResult.getMag()[k][l] < windowSize*0.75) {
+                if (singlePassResult.getSig2Noise()[k][l] > qMin && r_r < _e && r_c < _e && singlePassResult.getMag()[k][l] < windowSize*0.5) {
                     dr1_p[k][l] = singlePassResult.getV()[k][l];
                     dc1_p[k][l] = singlePassResult.getU()[k][l];
                     mag_p[k][l] = singlePassResult.getMag()[k][l];


### PR DESCRIPTION
- Median filter uses 0 value padding for out-of-bound indices for post-processing
- Multipass indexing fix
- Displacement vectors larger than 1/2 of the window size are filtered out

closes #207 
closes #202 