### PR TITLE
PIV fixes

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ImageActivity.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ImageActivity.java
@@ -174,7 +174,7 @@ public class ImageActivity extends AppCompatActivity {
 
     public void displayResults(View view) {
         // Pass PIV result data to ViewResultsActivity
-        PivResultData singlePassResult = resultData.get(PivResultData.SINGLE+PivResultData.PROCESSED+PivResultData.REPLACE);
+        PivResultData singlePassResult = resultData.get(PivResultData.SINGLE);
         assert singlePassResult != null;
 
         ViewResultsActivity.singlePass = singlePassResult;

--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ImageActivity.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ImageActivity.java
@@ -182,7 +182,12 @@ public class ImageActivity extends AppCompatActivity {
         if (pivParameters.isReplace()) {
             ViewResultsActivity.replacedPass = resultData.get(PivResultData.MULTI+PivResultData.PROCESSED+PivResultData.REPLACE);
         }
-        ViewResultsActivity.calibrated = singlePassResult.isCalibrated();
+
+        // calibration
+        ViewResultsActivity.calibrated = singlePassResult.isCalibrated() ||
+                ViewResultsActivity.multiPass.isCalibrated() ||
+                ViewResultsActivity.replacedPass.isCalibrated();
+
         ViewResultsActivity.backgroundSubtracted = singlePassResult.isBackgroundSubtracted();
 
         Intent displayIntent = new Intent(ImageActivity.this, ViewResultsActivity.class);

--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ViewResultsActivity.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ViewResultsActivity.java
@@ -94,6 +94,7 @@ public class ViewResultsActivity extends AppCompatActivity implements PositionCa
     private TextView infoText;
     private float currentX;
     private float currentY;
+    private static float conversionFactor;
 
     // From Image Activity
     public static PivResultData singlePass;
@@ -724,7 +725,8 @@ public class ViewResultsActivity extends AppCompatActivity implements PositionCa
             float v = (float) pivCorr.getCalibratedV()[pivCoords.y][pivCoords.x];
             float vort = (float) pivCorr.getCalibratedVorticity()[pivCoords.y][pivCoords.x];
             // because we're inverting the y axis, we also invert the v values
-            updatedText = settings.formatInfoString_physical((float) imgX, (float) dispY, u, -v, vort);
+            updatedText = settings.formatInfoString_physical((float) imgX, (float) dispY, u, -v, vort,
+                    pivCorr.getPixelToPhysicalRatio());
         } else {
             // compile the data
             float u = (float)pivCorr.getU()[pivCoords.y][pivCoords.x];

--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ViewResultsActivity.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/ViewResultsActivity.java
@@ -726,7 +726,7 @@ public class ViewResultsActivity extends AppCompatActivity implements PositionCa
             float vort = (float) pivCorr.getCalibratedVorticity()[pivCoords.y][pivCoords.x];
             // because we're inverting the y axis, we also invert the v values
             updatedText = settings.formatInfoString_physical((float) imgX, (float) dispY, u, -v, vort,
-                    pivCorr.getPixelToPhysicalRatio());
+                    (float) pivCorr.getPixelToPhysicalRatio(), (float) pivCorr.getUvConversion());
         } else {
             // compile the data
             float u = (float)pivCorr.getU()[pivCoords.y][pivCoords.x];

--- a/app/src/main/java/com/onrpiv/uploadmedia/Utilities/ResultSettings.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Utilities/ResultSettings.java
@@ -185,11 +185,13 @@ public class ResultSettings {
                 "\nVorticity: " + vort;
     }
 
-    public String formatInfoString_physical(float x, float y, float u, float v, float vort, double conversion) {
-        return "conversion factor xy (px -> cm): " + conversion + "\n" +
-                "x: " + ((int) x) + "\t\t\t" + "y: " + ((int) y) +
+    public String formatInfoString_physical(float x, float y, float u, float v, float vort,
+                                            float xyconversion, float uvconversion) {
+        return  "x: " + ((int) x) + "\t\t\t" + "y: " + ((int) y) +
                 "\nU: " + u + " cm/s\t\t\t" + "V: " + v + " cm/s" +
-                "\nVorticity: " + vort;
+                "\nVorticity: " + vort +
+                "\nconversion factor xy (px/cm): " + xyconversion +
+                "\nconversion factor uv ((px/cm)/dt -> cm/s): " + uvconversion;
     }
 
     public String debugString(int pivX, int pivY, double imgX, double imgY, float viewX, float viewY) {

--- a/app/src/main/java/com/onrpiv/uploadmedia/Utilities/ResultSettings.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Utilities/ResultSettings.java
@@ -185,8 +185,9 @@ public class ResultSettings {
                 "\nVorticity: " + vort;
     }
 
-    public String formatInfoString_physical(float x, float y, float u, float v, float vort) {
-        return "x: " + ((int) x) + "\t\t\t" + "y: " + ((int) y) +
+    public String formatInfoString_physical(float x, float y, float u, float v, float vort, double conversion) {
+        return "conversion factor xy (px -> cm): " + conversion + "\n" +
+                "x: " + ((int) x) + "\t\t\t" + "y: " + ((int) y) +
                 "\nU: " + u + " cm/s\t\t\t" + "V: " + v + " cm/s" +
                 "\nVorticity: " + vort;
     }

--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivFunctions.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivFunctions.java
@@ -916,7 +916,7 @@ public class PivFunctions {
         // add padding to grayscale frames
         Mat paddedGray1 = new Mat();
         Mat paddedGray2 = new Mat();
-        int padding = (int) Math.sqrt(windowSize);
+        int padding = windowSize + 1;
         Core.copyMakeBorder(grayFrame1, paddedGray1, padding, padding, padding, padding, Core.BORDER_CONSTANT, Scalar.all(0d));
         Core.copyMakeBorder(grayFrame2, paddedGray2, padding, padding, padding, padding, Core.BORDER_CONSTANT, Scalar.all(0d));
 

--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivFunctions.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivFunctions.java
@@ -845,11 +845,6 @@ public class PivFunctions {
     public PivResultData vectorPostProcessing(PivResultData passResult, boolean replacement,
                                               String resultName) {
 
-        if (replacement) {
-            resultName += PivResultData.REPLACE;
-            passResult = replaceMissingVectors(passResult, resultName);
-        }
-
         double[][] dr1_p = new double[fieldRows][fieldCols];
         double[][] dc1_p = new double[fieldRows][fieldCols];
         double[][] mag_p = new double[fieldRows][fieldCols];
@@ -888,8 +883,15 @@ public class PivFunctions {
             }
         }
 
-        return new PivResultData(resultName, dc1_p, dr1_p, mag_p,
+        PivResultData processedResult = new PivResultData(resultName, dc1_p, dr1_p, mag_p,
                 passResult.getSig2Noise(), getCoordinates(), cols, rows, dt);
+
+        if (replacement) {
+            resultName += PivResultData.REPLACE;
+            processedResult = replaceMissingVectors(processedResult, resultName);
+        }
+
+        return processedResult;
     }
 
     public PivResultData calculateMultipass(PivResultData pivResultData, String resultName, boolean fft,

--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivResultData.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivResultData.java
@@ -22,7 +22,8 @@ public class PivResultData implements Serializable {
     private int stepY;
     private boolean calibrated = false;
     private boolean backgroundSubtracted = false;
-    private double pixelToPhysicalRatio = 1d;
+    private double pixelToPhysicalRatio;
+    private double uvConversion;
     private String physicalMetric = "cm/s";
 
     // intent/io keys
@@ -115,6 +116,7 @@ public class PivResultData implements Serializable {
     public void setPixelToPhysicalRatio(double ratio, int fieldRows, int fieldCols) {
         pixelToPhysicalRatio = ratio;
         calculatePhysicalVectors(fieldRows, fieldCols);
+        calibrated = true;
     }
 
     public String getPhysicalMetric() {
@@ -202,13 +204,15 @@ public class PivResultData implements Serializable {
         _mag_calib = new double[fieldRows][fieldCols];
         _vort_calib = new double[fieldRows][fieldCols];
 
+        uvConversion = (1d / pixelToPhysicalRatio) / _dt;
+
         for (int i = 0; i < fieldRows; i++) {
             for (int j = 0; j < fieldCols; j++) {
-                _u_calib[i][j] = (_u[i][j] / pixelToPhysicalRatio) / _dt;
-                _v_calib[i][j] = (_v[i][j] / pixelToPhysicalRatio) / _dt;
-                _mag_calib[i][j] = (_mag[i][j] / pixelToPhysicalRatio) / _dt;
+                _u_calib[i][j] = _u[i][j] * uvConversion;
+                _v_calib[i][j] = _v[i][j] * uvConversion;
+                _mag_calib[i][j] = _mag[i][j] * uvConversion;
                 if (null != _vort) {  // some correlations won't have vorticity values
-                    _vort_calib[i][j] = (_vort[i][j] / pixelToPhysicalRatio) / _dt;
+                    _vort_calib[i][j] = _vort[i][j] * uvConversion;
                 }
             }
         }

--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivResultData.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivResultData.java
@@ -22,8 +22,8 @@ public class PivResultData implements Serializable {
     private int stepY;
     private boolean calibrated = false;
     private boolean backgroundSubtracted = false;
-    private double pixelToPhysicalRatio;
-    private double uvConversion;
+    private double pixelToPhysicalRatio = 1d;
+    private double uvConversion = 1d;
     private String physicalMetric = "cm/s";
 
     // intent/io keys
@@ -198,6 +198,10 @@ public class PivResultData implements Serializable {
         backgroundSubtracted = bool;
     }
 
+    public double getUvConversion() {
+        return uvConversion;
+    }
+
     private void calculatePhysicalVectors(int fieldRows, int fieldCols) {
         _u_calib = new double[fieldRows][fieldCols];
         _v_calib = new double[fieldRows][fieldCols];
@@ -217,12 +221,4 @@ public class PivResultData implements Serializable {
             }
         }
     }
-
-//    private void applyTimeDelta(double[][] vectorComponent) {
-//        for (int i = 0; i < _interrY.length; i++) {
-//            for (int j = 0; j < _interrX.length; j++) {
-//                vectorComponent[i][j] *= _dt;
-//            }
-//        }
-//    }
 }

--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivRunner.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivRunner.java
@@ -98,7 +98,6 @@ public class PivRunner implements ProgressUpdateInterface {
                 resultData.put(singlePassResult.getName(), singlePassResult);
                 pivFunctions.saveVectorsValues(singlePassResult, singlePassResult.getName());
 
-                setMessage("Post-Processing Single Pass PIV");
                 PivResultData singlePassProcessed =
                         pivFunctions.vectorPostProcessing(singlePassResult, true,
                                 PivResultData.SINGLE+PivResultData.PROCESSED);
@@ -121,7 +120,6 @@ public class PivRunner implements ProgressUpdateInterface {
                 resultData.put(multipassResults.getName(), multipassResults);
                 pivFunctions.saveVectorsValues(multipassResults, multipassResults.getName());
 
-                setMessage("Post-Processing Multi-Pass PIV");
                 PivResultData multiPassProcessed = pivFunctions.vectorPostProcessing(multipassResults,
                         parameters.isReplace(), PivResultData.MULTI+PivResultData.PROCESSED);
 
@@ -138,15 +136,13 @@ public class PivRunner implements ProgressUpdateInterface {
                 if (parameters.getCameraCalibrationResult() != null) {
                     setMessage("Applying Camera Calibration");
 
-                    // singlepass processed
-                    singlePassProcessed.setPixelToPhysicalRatio(parameters.getCameraCalibrationResult().ratio,
+                    // singlepass
+                    singlePassResult.setPixelToPhysicalRatio(parameters.getCameraCalibrationResult().ratio,
                             pivFunctions.getFieldRows(), pivFunctions.getFieldCols());
 
-                    pivFunctions.saveVectorCentimeters(singlePassProcessed,
+                    pivFunctions.saveVectorCentimeters(singlePassResult,
                             parameters.getCameraCalibrationResult().ratio,
-                            "CENTIMETERS_" + singlePassProcessed.getName());
-
-                    singlePassProcessed.setCalibrated(true);
+                            "CENTIMETERS_" + singlePassResult.getName());
 
                     // multipass
                     multipassResults.setPixelToPhysicalRatio(parameters.getCameraCalibrationResult().ratio,
@@ -156,8 +152,6 @@ public class PivRunner implements ProgressUpdateInterface {
                             parameters.getCameraCalibrationResult().ratio,
                             "CENTIMETERS_" + multipassResults.getName());
 
-                    multipassResults.setCalibrated(true);
-
                     // multipass processed
                     multiPassProcessed.setPixelToPhysicalRatio(parameters.getCameraCalibrationResult().ratio,
                             pivFunctions.getFieldRows(), pivFunctions.getFieldCols());
@@ -165,8 +159,6 @@ public class PivRunner implements ProgressUpdateInterface {
                     pivFunctions.saveVectorCentimeters(multiPassProcessed,
                             parameters.getCameraCalibrationResult().ratio,
                             "CENTIMETERS_" + multiPassProcessed.getName());
-
-                    multiPassProcessed.setCalibrated(true);
                 }
 
 

--- a/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivRunner.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/pivFunctions/PivRunner.java
@@ -95,6 +95,7 @@ public class PivRunner implements ProgressUpdateInterface {
                 singlePassResult.setBackgroundSubtracted(backgroundSub);
 
                 // save raw single pass
+                resultData.put(singlePassResult.getName(), singlePassResult);
                 pivFunctions.saveVectorsValues(singlePassResult, singlePassResult.getName());
 
                 setMessage("Post-Processing Single Pass PIV");


### PR DESCRIPTION
- Viewable single pass results are unprocessed -> closes #288 
- Replacement occurs after post-processing -> closes #287 
- Multipass padding is set to windowsize + 1 -> closes #284 
- xy (pixels per cm) conversion factor added to results information -> closes #283 
- uv (cm per s) conversion factor added to results information -> closes #283 