### PR TITLE
Load Experiments radio button selection fix

### DIFF
--- a/app/src/main/java/com/onrpiv/uploadmedia/Experiment/Popups/LoadExperimentPopup.java
+++ b/app/src/main/java/com/onrpiv/uploadmedia/Experiment/Popups/LoadExperimentPopup.java
@@ -38,9 +38,9 @@ public class LoadExperimentPopup extends Popup {
         radioListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                currentlySelected.toggle();
+                currentlySelected.setChecked(false);
                 currentlySelected = (RadioButton) v;
-                currentlySelected.toggle();
+                currentlySelected.setChecked(true);
             }
         };
 


### PR DESCRIPTION
Previously selected radio buttons in Load Experiments are properly deselected.

closes #295 